### PR TITLE
Fix gha new pull request for set-env deprecated

### DIFF
--- a/.github/workflows/new-pull-request.yaml
+++ b/.github/workflows/new-pull-request.yaml
@@ -22,7 +22,7 @@ jobs:
           echo "CURRENT_VERSION = $CURRENT_VERSION"
           NEXT_VERSION=$(echo $CURRENT_VERSION | perl -ne 'if ($_ =~ /^v(\d+)\.(\d+)\.(\d+)$/) { $v = $3; $v++; print "v$1.$2.$v\n" } else { print "Invalid tag format."; exit 1 }')
           echo "NEXT_VERSION = $NEXT_VERSION"
-          echo "::set-env name=NEXT_VERSION::$(echo $NEXT_VERSION)"
+          echo "NEXT_VERSION=$(echo $NEXT_VERSION)" >> $GITHUB_ENV
 
       - name: Empty commit
         run: |


### PR DESCRIPTION
## 概要

set-envがdeprecatedになったため修正

## 詳細

[\[GitHub\]Actionsで非推奨となるset\-envとadd\-pathへの対応について確認してみた \#GitHub \| DevelopersIO](https://dev.classmethod.jp/articles/replace-deprecated-method-on-actions/)