### PR TITLE
verup for gha new pull request

### DIFF
--- a/.github/workflows/new-pull-request.yaml
+++ b/.github/workflows/new-pull-request.yaml
@@ -31,12 +31,13 @@ jobs:
 
       - name: Create a pull request with a new release branch
         id: create_pull_request
-        uses: peter-evans/create-pull-request@v2
+        uses: peter-evans/create-pull-request@v4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           branch: release/${{ env.NEXT_VERSION }}
           base: main
           title: "Release ${{ env.NEXT_VERSION }}"
+          draft: true
           body: |
             ## Pull-requests in this release
 


### PR DESCRIPTION
## 概要

`peter-evans/create-pull-request@v2` が古くジョブ実行エラーになっていたため、verup 

## 詳細

[Create Pull Request · Actions · GitHub Marketplace](https://github.com/marketplace/actions/create-pull-request)
