### PR TITLE
additional verup for gha new pull request

### DIFF
--- a/.github/workflows/new-pull-request.yaml
+++ b/.github/workflows/new-pull-request.yaml
@@ -9,7 +9,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - run: |
           git fetch origin main
       - name: Git config
@@ -42,7 +42,7 @@ jobs:
             ## Pull-requests in this release
 
       - name: Post to slack when success
-        uses: 8398a7/action-slack@v2
+        uses: 8398a7/action-slack@v3
         with:
           status: custom
           payload: |


### PR DESCRIPTION
## 概要

`actions/checkout` と `8398a7/action-slack` も古かったためverup

## 詳細

- [actions/checkout](https://github.com/actions/checkout)
  - https://github.com/marketplace/actions/checkout
- [8398a7/action\-slack](https://github.com/8398a7/action-slack)
  - https://github.com/marketplace/actions/action-slack
  - https://action-slack.netlify.app/