### PR TITLE
fix slack notify for gha new pull request

### DIFF
--- a/.github/workflows/new-pull-request.yaml
+++ b/.github/workflows/new-pull-request.yaml
@@ -59,7 +59,6 @@ jobs:
                 ]
               }]
             }
-        if: failure()
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}


### PR DESCRIPTION
## 概要

次リリースブランチ、PR作成後のslack通知が飛ばなかったため修正

## 詳細
