### PR TITLE
Fix pull-request-number

### DIFF
--- a/.github/workflows/new-pull-request.yaml
+++ b/.github/workflows/new-pull-request.yaml
@@ -54,7 +54,7 @@ jobs:
                 "fields": [
                   {
                     title: "Pull Request",
-                    value: "https://github.com/${{ github.repository }}/pull/${{ steps.create_pull_request.outputs.pr_number }}",
+                    value: "https://github.com/${{ github.repository }}/pull/${{ steps.cpr.outputs.pull-request-number }}",
                     short: false
                   }
                 ]


### PR DESCRIPTION
## 概要

`steps.create_pull_request.outputs.pr_number` を
`steps.cpr.outputs.pull-request-number` に変更

## 詳細

[peter\-evans/create\-pull\-request](https://github.com/peter-evans/create-pull-request)